### PR TITLE
Further fix to commerce_invoice_action_create_from_order()

### DIFF
--- a/commerce_invoice.rules.inc
+++ b/commerce_invoice.rules.inc
@@ -113,7 +113,10 @@ function commerce_invoice_action_load_current($order) {
 /**
  * Action: Create invoice for a given order.
  */
-function commerce_invoice_action_create_from_order($order, InvoiceNumberPattern $pattern = NULL, $cancel_existing = TRUE) {
+function commerce_invoice_action_create_from_order($order, $pattern = NULL, $cancel_existing = TRUE) {
+  if (is_string($pattern)) {
+    $pattern = commerce_invoice_number_pattern_load($pattern);
+  }
   $invoice = commerce_invoice_create_from_order($order, $pattern, $cancel_existing);
 
   return ['commerce_invoice' => $invoice];


### PR DESCRIPTION
Apparently 7d07baeb3536e38cecc042545c3202d729112a8c introduced this dumb bug

```
PHP error:  Argument 2 passed to                                  [error]
commerce_invoice_action_create_from_order() must be an instance of Drupal\commerce_invoice\Entity\InvoiceNumberPattern, string given in
modules/contrib/commerce_invoice/commerce_invoice.rules.inc on line 11
```